### PR TITLE
Fix: Add explicit tags to Dockerfile source images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine as gobuild
+FROM golang:1.22.1-alpine3.19 as gobuild
 
 RUN apk add --no-cache libpcap-dev git gcc libc-dev libcap-utils
 WORKDIR github.com/nberlee/bonjour-reflector
@@ -8,7 +8,7 @@ RUN GOOS=linux go build -ldflags="-s -w"
 RUN setcap cap_net_raw+ep bonjour-reflector
 
 
-FROM alpine as rootfs
+FROM alpine:3.19.1 as rootfs
 RUN apk --no-cache add libpcap
 COPY --from=gobuild /go/github.com/nberlee/bonjour-reflector/bonjour-reflector /
 RUN find /usr/bin /usr/sbin /sbin /bin  -type l -delete && busybox grep -v libpcap /etc/apk/world | busybox xargs apk del 


### PR DESCRIPTION
This PR adds explicit version tags to the `golang` and `alpine` Docker image sources in `Dockerfile`.

This project already has a valid Dependabot configuration for scanning Docker image versions, but without explicit tags Dependabot can't do anything with them, putting the bonjour-reflector image at risk of security vulnerabilities from un-patched base images.

This change should add automated Dependabot PRs for base image updates, which in my opinion is critical for a container that will run in an environment such as an edge router.