### PR TITLE
Feature/Fix: Dockerfile - Make roughly 43% smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,23 @@
 FROM golang:alpine as gobuild
 
-RUN apk add --no-cache libpcap-dev git gcc libc-dev libcap-utils
+RUN apk add --no-cache libpcap-dev git gcc libc-dev libcap-utils upx
 WORKDIR github.com/nberlee/bonjour-reflector
 COPY go.* .
 COPY *.go .
 RUN GOOS=linux go build -ldflags="-s -w"
+RUN upx bonjour-reflector
 RUN setcap cap_net_raw+ep bonjour-reflector
 
 
 FROM alpine as rootfs
 RUN apk --no-cache add libpcap
-COPY --from=gobuild /go/github.com/nberlee/bonjour-reflector/bonjour-reflector /
-RUN find /usr/bin /usr/sbin /sbin /bin  -type l -delete && busybox grep -v libpcap /etc/apk/world | busybox xargs apk del 
 
+
+FROM scratch as intermediate
+COPY --from=rootfs /lib/*musl* /lib/
+COPY --from=rootfs /usr/lib/*pcap* /usr/lib/
+COPY --from=gobuild /go/github.com/nberlee/bonjour-reflector/bonjour-reflector /bonjour-reflector
 
 FROM scratch
-COPY --from=rootfs / /
+COPY --from=intermediate / /
 CMD ["/bonjour-reflector"]


### PR DESCRIPTION
Using a combination of `upx` and a choosier copy I was able to reduce the final image size to 4.7M from the top of main.  I have not yet tested this on a routeros target as I haven't got containers enabled in my test environment yet, but I believe the changes should be safe.