### PR TITLE
FIX: Minor Mikrotik documentation fix.

### DIFF
--- a/docs/RouterOS/README.md
+++ b/docs/RouterOS/README.md
@@ -170,5 +170,5 @@ If you see packets going in but not coming out, run the container in verbose mod
 
 Were `response packet` means that there is actual SSDP sessions set up. Which is a good sign.
 
-If you see packets coming out of the container but no response packet are received make absolute sure you have assigned the correct vlan ids on the bridge for the veth1-reflector interface. Also check if the veth1-reflector interface port is set to `ingress-filtering=no` and `frame-types=admit-only-vlan-tagged-and-priority-tagged`.
+If you see packets coming out of the container but no response packet are received make absolute sure you have assigned the correct vlan ids on the bridge for the veth1-reflector interface. Also check if the veth1-reflector interface port is set to `ingress-filtering=no` and `frame-types=admit-only-vlan-tagged`.
 


### PR DESCRIPTION
The "Troubleshooting" part of the Mikrotik related documentation asks user to verify that `frame-types` parameter for the interface is set to `admit-only-vlan-tagged-and-priority-tagged`.
Such value is not valid in Mirotik, it's either `admit-only-vlan-untagged-and-priority-tagged` or `admit-only-vlan-tagged` (or `admit-all`).

Considering Reflector deals with tagged packets, changing it to `admit-only-vlan-tagged`  which should be the right value.